### PR TITLE
feature: Add ability to setView based on bounds rather than center

### DIFF
--- a/lib/components/ReactBingmaps/ReactBingmaps.js
+++ b/lib/components/ReactBingmaps/ReactBingmaps.js
@@ -107,8 +107,11 @@ var ReactBingmaps = function (_Component) {
 		key: 'componentWillReceiveProps',
 		value: function componentWillReceiveProps(nextProps) {
 			var mapReference = nextProps.id ? '#' + nextProps.id : '.react-bingmaps';
-			if (this.props.center.join() !== nextProps.center.join()) {
+			if (this.props.center && this.props.center.join(',') !== nextProps.center.join(',')) {
 				this.setMapCenter(nextProps.center, mapReference);
+			}
+			if (this.props.bounds && this.props.bounds.join(',') !== nextProps.bounds.join(',')) {
+				this.setMapBounds(nextProps.bounds, mapReference);
 			}
 			if (this.props.zoom !== nextProps.zoom) {
 				this.setMapZoom(nextProps.zoom, mapReference);
@@ -154,6 +157,7 @@ var ReactBingmaps = function (_Component) {
 		key: 'reactBingmaps',
 		value: function reactBingmaps(props, Microsoft) {
 			var bingmapKey = props.bingmapKey,
+			    bounds = props.bounds,
 			    center = props.center,
 			    mapTypeId = props.mapTypeId,
 			    zoom = props.zoom,
@@ -179,7 +183,11 @@ var ReactBingmaps = function (_Component) {
 						credentials: bingmapKey
 					});
 				}
-				this.setMapCenter(center, mapReference);
+				if (center) {
+					this.setMapCenter(center, mapReference);
+				} else if (bounds) {
+					this.setMapBounds(bounds, mapReference);
+				}
 				this.setMapTypeId(mapTypeId, center, heading, mapReference);
 				this.setMapZoom(zoom, mapReference);
 				this.setMapNavigationBarMode(navigationBarMode, mapReference);
@@ -203,6 +211,18 @@ var ReactBingmaps = function (_Component) {
 			if (map[mapReference] && center && center[0] && center[1]) {
 				map[mapReference].setView({
 					center: new Microsoft.Maps.Location(center[0], center[1])
+				});
+			}
+		}
+	}, {
+		key: 'setMapBounds',
+		value: function setMapBounds(bounds, mapReference) {
+			if (map[mapReference] && bounds && bounds instanceof Array) {
+				var rect = Microsoft.Maps.LocationRect.fromLocations(bounds.map(function (loc) {
+					return new Microsoft.Maps.Location(loc[0], loc[1]);
+				}));
+				map[mapReference].setView({
+					bounds: rect
 				});
 			}
 		}
@@ -676,6 +696,7 @@ exports.default = ReactBingmaps;
 
 ReactBingmaps.propTypes = {
 	bingmapKey: _propTypes2.default.oneOfType([_propTypes2.default.string, _propTypes2.default.number]),
+	bounds: _propTypes2.default.arrayOf(_propTypes2.default.arrayOf(_propTypes2.default.number)),
 	center: _propTypes2.default.arrayOf(_propTypes2.default.number),
 	mapTypeId: _propTypes2.default.string,
 	navigationBarMode: _propTypes2.default.string,
@@ -736,6 +757,7 @@ ReactBingmaps.propTypes = {
 };
 ReactBingmaps.defaultProps = {
 	bingmapKey: undefined,
+	bounds: undefined,
 	center: undefined,
 	mapTypeId: undefined,
 	navigationBarMode: undefined,

--- a/src/node_modules/components/ReactBingmaps/ReactBingmaps.js
+++ b/src/node_modules/components/ReactBingmaps/ReactBingmaps.js
@@ -61,8 +61,11 @@ class ReactBingmaps extends Component {
 	}
 	componentWillReceiveProps(nextProps){
 		let mapReference = nextProps.id ? ('#' + nextProps.id) : '.react-bingmaps';
-		if(this.props.center.join() !== nextProps.center.join()){
+		if(this.props.center && this.props.center.join(',') !== nextProps.center.join(',')){
 			this.setMapCenter(nextProps.center, mapReference);
+		}
+		if(this.props.bounds && this.props.bounds.join(',') !== nextProps.bounds.join(',')){
+			this.setMapBounds(nextProps.bounds, mapReference);
 		}
 		if(this.props.zoom !== nextProps.zoom){
 			this.setMapZoom(nextProps.zoom, mapReference);
@@ -106,8 +109,9 @@ class ReactBingmaps extends Component {
 	}
 	reactBingmaps(props,  Microsoft){
 		const { 
-			bingmapKey, 
-			center, 
+			bingmapKey,
+			bounds,
+			center,
 			mapTypeId,
 			zoom,
 			navigationBarMode,
@@ -132,7 +136,12 @@ class ReactBingmaps extends Component {
 					credentials: bingmapKey
 				});
 			}
-			this.setMapCenter(center, mapReference);
+			if (center) {
+				this.setMapCenter(center, mapReference);
+			}
+			else if (bounds) {
+				this.setMapBounds(bounds, mapReference);
+			}
 			this.setMapTypeId(mapTypeId, center, heading, mapReference);
 			this.setMapZoom(zoom, mapReference);
 			this.setMapNavigationBarMode(navigationBarMode, mapReference);
@@ -155,6 +164,18 @@ class ReactBingmaps extends Component {
 			map[mapReference].setView({
 	            center: new Microsoft.Maps.Location(center[0], center[1])
 	        });
+		}
+	}
+	setMapBounds(bounds, mapReference) {
+		if (map[mapReference] && bounds && bounds instanceof Array) {
+			var rect = Microsoft.Maps.LocationRect.fromLocations(
+				bounds.map(function(loc) {
+					return new Microsoft.Maps.Location(loc[0], loc[1]);
+				})
+			);
+			map[mapReference].setView({
+				bounds: rect,
+			});
 		}
 	}
 	setMapTypeId(mapTypeId, center, heading, mapReference){
@@ -641,6 +662,7 @@ export default ReactBingmaps;
 
 ReactBingmaps.propTypes = {
 	bingmapKey: PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]),
+	bounds: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
 	center: PropTypes.arrayOf(PropTypes.number),
 	mapTypeId: PropTypes.string,
 	navigationBarMode: PropTypes.string,
@@ -709,6 +731,7 @@ ReactBingmaps.propTypes = {
 }
 ReactBingmaps.defaultProps = {
 	bingmapKey: undefined,
+	bounds: undefined,
 	center: undefined,
 	mapTypeId: undefined,
 	navigationBarMode: undefined,


### PR DESCRIPTION
Adds `bounds` prop, which is an array of tuples of the form [lat, lng]
that represents points the map should contain within its view.